### PR TITLE
Fix how templates are found in directories

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # jinjar (development version)
 
+* `path_loader()` now correctly supports directories that are not the working directory (#11).
+
 # jinjar 0.1.0
 
 Initial version on CRAN.

--- a/src/inja/inja.hpp
+++ b/src/inja/inja.hpp
@@ -4229,7 +4229,7 @@ class Environment {
   TemplateStorage template_storage;
 
 public:
-  Environment() : Environment("") {}
+  Environment() : Environment("./") {}
 
   explicit Environment(const std::string &global_path) : input_path(global_path), output_path(global_path) {}
 
@@ -4292,7 +4292,7 @@ public:
 
   Template parse(nonstd::string_view input) {
     Parser parser(parser_config, lexer_config, template_storage, function_storage);
-    return parser.parse(input);
+    return parser.parse(input, input_path);
   }
 
   Template parse_template(const std::string &filename) {

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -35,7 +35,8 @@ PathLoader::PathLoader(const cpp11::list& loader) {
 }
 
 inja::Environment PathLoader::init_environment() {
-  return(inja::Environment(path));
+  // inja expects trailing slash
+  return(inja::Environment(path + "/"));
 }
 
 

--- a/tests/testthat/_snaps/render.md
+++ b/tests/testthat/_snaps/render.md
@@ -1,7 +1,7 @@
 # include tag
 
     Code
-      render(fs::path("foo"), name = "world", .config = jinjar_config(
+      render(fs::path("templates/foo"), name = "world", .config = jinjar_config(
         ignore_missing_files = TRUE))
     Output
       [1] "Welcome: "
@@ -9,7 +9,8 @@
 ---
 
     Code
-      render(fs::path("foo"), name = "world", .config = jinjar_config(path_loader(fs::path_wd())))
+      render(fs::path("foo"), name = "world", .config = jinjar_config(path_loader(fs::path_wd(
+        "templates"))))
     Output
       [1] "Welcome: Hello world!\n"
 

--- a/tests/testthat/test-render.R
+++ b/tests/testthat/test-render.R
@@ -38,20 +38,20 @@ test_that("include tag", {
   aux <- "Hello {{ name }}!"
 
   with_dir_tree(list(
-    "foo" = src,
-    "bar" = aux
+    "templates/foo" = src,
+    "templates/bar" = aux
   ), {
 
     expect_error(render(fs::path("foo"), name = "world"))
     expect_snapshot(render(
-      fs::path("foo"),
+      fs::path("templates/foo"),
       name = "world",
       .config = jinjar_config(ignore_missing_files = TRUE)
     ))
     expect_snapshot(render(
       fs::path("foo"),
       name = "world",
-      .config = jinjar_config(path_loader(fs::path_wd()))
+      .config = jinjar_config(path_loader(fs::path_wd("templates")))
     ))
   })
 


### PR DESCRIPTION
Fixes #10 

* jinjar always passes the main template to inja as a string. But inja ignores the search directory when the main template is passed as a string (it instead searches the working directory). I think this is a bug with inja.
* When fixing this, I realized that inja expects the search directory to have a trailing slash.
* Adjusted unit test so it looks for templates within a directory