### PR TITLE
Print templates with color

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # jinjar (development version)
 
-* When printing parsed template objects, output is now stylized using the cli package.
+* When printing parsed template objects, output is now stylized using the cli package (#18).
     * Variables are green
     * Control blocks are blue
     * Comments are italic grey

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,10 @@
 # jinjar (development version)
 
-* When printing parsed template objects, output is now stylized using the cli package (#18).
+* `print.jinjar_template()` now highlights templating blocks using the cli package (#18).
     * Variables are green
     * Control blocks are blue
     * Comments are italic grey
+* `print.jinjar_template()` gains an `n` argument to control the number of lines displayed (#18).
 
 
 # jinjar 0.2.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # jinjar (development version)
 
+* When printing parsed template objects, output is now stylized using the cli package.
+    * Variables are green
+    * Control blocks are blue
+    * Comments are italic grey
+
+
 # jinjar 0.2.0
 
 * New `parse_template()` to parse a template once and `render()` it multiple times (#13).

--- a/R/check.R
+++ b/R/check.R
@@ -10,6 +10,13 @@ check_bool <- function(x, arg = caller_arg(x), call = caller_env()) {
   }
 }
 
+check_count <- function(x, inf = FALSE, arg = caller_arg(x), call = caller_env()) {
+  finite <- if (inf) NULL else TRUE
+  if (!is_scalar_integerish(x, finite = finite) || is.na(x) || x <= 0) {
+    cli::cli_abort("{.arg {arg}} must be a positive integer", call = call)
+  }
+}
+
 check_file_exists <- function(x, arg = caller_arg(x), call = caller_env()) {
   if (!fs::file_exists(x) || fs::dir_exists(x)) {
     cli::cli_abort("File does not exist: {.file {x}}", call = call)

--- a/R/parse.R
+++ b/R/parse.R
@@ -16,6 +16,9 @@
 #' * `vignette("template-syntax")` describes how to write templates.
 #' @examples
 #' x <- parse_template("Hello {{ name }}!")
+#'
+#' x
+#'
 #' render(x, name = "world")
 #' @name parse
 #' @export
@@ -93,7 +96,7 @@ style_template <- function(x) {
     row <- blocks[i_row,]
 
     if (ix_write < row$ix_open) {
-      output <- c(output, style_block(x, "", ix_write, row$ix_open - 1))
+      output <- c(output, style_block(x, "text", ix_write, row$ix_open - 1))
       ix_write <- row$ix_open
     }
 
@@ -102,8 +105,8 @@ style_template <- function(x) {
       ix_write <- row$ix_close + 1
     }
   }
-  if (ix_write < nchar(x)) {
-    output <- c(output, style_block(x, "", ix_write, nchar(x)))
+  if (ix_write <= nchar(x)) {
+    output <- c(output, style_block(x, "text", ix_write, nchar(x)))
   }
 
   # stitch blocks
@@ -134,7 +137,7 @@ style_block <- function(x, type, ix_open, ix_close) {
   txt_block <- substr(x, ix_open, ix_close)
 
   if (type == "comment") {
-    cli::col_grey(txt_block)
+    cli::style_italic(cli::col_grey(txt_block))
   } else if (type == "block") {
     cli::col_blue(txt_block)
   } else if (type == "variable") {

--- a/R/parse.R
+++ b/R/parse.R
@@ -59,7 +59,11 @@ parse_template.fs_path <- function(.x, .config = default_config()) {
 
 #' @export
 print.jinjar_template <- function(x, ...) {
-  cli::cli_verbatim(style_template(x))
+  if (cli::num_ansi_colors() > 1) {
+    cli::cli_verbatim(style_template(x))
+  } else {
+    cat(x)
+  }
 
   invisible(x)
 }
@@ -107,8 +111,8 @@ style_template <- function(x) {
 }
 
 find_blocks <- function(x, type, open, close) {
-  ix_open <- as.integer(gregexpr(open, x, fixed = TRUE)[[1]])
-  ix_close <- as.integer(gregexpr(close, x, fixed = TRUE)[[1]])
+  ix_open <- gregexpr(open, x, fixed = TRUE)[[1]]
+  ix_close <- gregexpr(close, x, fixed = TRUE)[[1]]
 
   # no blocks found
   if (all(ix_open == -1L)) {

--- a/R/parse.R
+++ b/R/parse.R
@@ -59,7 +59,26 @@ parse_template.fs_path <- function(.x, .config = default_config()) {
 
 #' @export
 print.jinjar_template <- function(x, ...) {
-  cat(x)
+  find_blocks <- function(x, block) {
+    open <- attr(x, "config")[[paste0(block, "_open")]]
+    close <- attr(x, "config")[[paste0(block, "_close")]]
 
+    ix_open <- as.integer(gregexpr(open, x, fixed = TRUE)[[1]])
+    ix_close <- as.integer(gregexpr(close, x, fixed = TRUE)[[1]])
+
+    # ignore unmatched open/close patterns
+    find_matching_close <- function(x) min(ix_close[ix_close > x])
+    ix_close_match <- vapply(ix_open, find_matching_close, FUN.VALUE = 0L)
+
+    ix_open <- ix_open[c(1, diff(ix_close_match)) != 0]
+    ix_close <- ix_close[ix_close %in% ix_close_match]
+
+    print(ix_open)
+    print(ix_close)
+  }
+
+  find_blocks(x, "variable")
+
+  cat(x)
   invisible(x)
 }

--- a/R/parse.R
+++ b/R/parse.R
@@ -73,7 +73,7 @@ print.jinjar_template <- function(x, ..., n = 10) {
   n_more <- 0L
 
   # truncate output
-  if (!is.infinite(n)) {
+  if (is.finite(n)) {
     lines <- strsplit(x, "\n", fixed = TRUE)[[1]]
     n_found <- length(lines)
 

--- a/R/parse.R
+++ b/R/parse.R
@@ -62,7 +62,7 @@ parse_template.fs_path <- function(.x, .config = default_config()) {
   parse_template(read_utf8(.x), .config)
 }
 
-#' @param x Object to format or print.
+#' @param x Object to print.
 #' @param n Number of lines to show. If `Inf`, will print all lines. Default: `10`.
 #' @inheritParams rlang::args_dots_empty
 #' @rdname parse

--- a/R/render.R
+++ b/R/render.R
@@ -7,9 +7,7 @@
 #' * A path to a template file (use [fs::path()]).
 #' * A parsed template (use [parse_template()]).
 #' @param ... <[`dynamic-dots`][rlang::dyn-dots]> Data passed to the template.
-#' @param .config The engine configuration. The default matches Jinja defaults,
-#'   but you can use [jinjar_config()] to customize things like syntax delimiters,
-#'   whitespace control, and loading auxiliary templates.
+#' @inheritParams parse
 #' @return String containing rendered template.
 #'
 #' @seealso

--- a/man/parse.Rd
+++ b/man/parse.Rd
@@ -27,7 +27,7 @@ parse_template(.x, .config)
 but you can use \code{\link[=jinjar_config]{jinjar_config()}} to customize things like syntax delimiters,
 whitespace control, and loading auxiliary templates.}
 
-\item{x}{Object to format or print.}
+\item{x}{Object to print.}
 
 \item{...}{These dots are for future extensions and must be empty.}
 

--- a/man/parse.Rd
+++ b/man/parse.Rd
@@ -5,6 +5,7 @@
 \alias{parse_template}
 \alias{parse_template.character}
 \alias{parse_template.fs_path}
+\alias{print.jinjar_template}
 \title{Parse template}
 \usage{
 parse_template(.x, .config)
@@ -12,6 +13,8 @@ parse_template(.x, .config)
 \method{parse_template}{character}(.x, .config = default_config())
 
 \method{parse_template}{fs_path}(.x, .config = default_config())
+
+\method{print}{jinjar_template}(x, ..., n = 10)
 }
 \arguments{
 \item{.x}{The template. Choices:
@@ -23,6 +26,12 @@ parse_template(.x, .config)
 \item{.config}{The engine configuration. The default matches Jinja defaults,
 but you can use \code{\link[=jinjar_config]{jinjar_config()}} to customize things like syntax delimiters,
 whitespace control, and loading auxiliary templates.}
+
+\item{x}{Object to format or print.}
+
+\item{...}{These dots are for future extensions and must be empty.}
+
+\item{n}{Number of lines to show. If \code{Inf}, will print all lines. Default: \code{10}.}
 }
 \value{
 A \code{"jinjar_template"} object.

--- a/man/parse.Rd
+++ b/man/parse.Rd
@@ -35,6 +35,9 @@ template syntax.
 }
 \examples{
 x <- parse_template("Hello {{ name }}!")
+
+x
+
 render(x, name = "world")
 }
 \seealso{

--- a/tests/testthat/_snaps/render.md
+++ b/tests/testthat/_snaps/render.md
@@ -1,9 +1,102 @@
-# storing parsed document works
+# printing parsed document works [plain]
 
     Code
-      print(x)
-    Output
-      Hello {{ name }}!
+      print(x, n = Inf)
+    Message
+      Humans of A New Hope
+      {# put a comment here #}
+      {% for person in people -%}
+      {% if "A New Hope" in person.films and default(person.species, "Unknown") == "Human" -%}
+      * {{ person.name }} ({{ person.homeworld }})
+      {% endif -%}
+      {% endfor -%}
+
+---
+
+    Code
+      print(x, n = 5)
+    Message
+      Humans of A New Hope
+      {# put a comment here #}
+      {% for person in people -%}
+      {% if "A New Hope" in person.films and default(person.species, "Unknown") == "Human" -%}
+      * {{ person.name }} ({{ person.homeworld }})
+      i ... with 2 more lines
+
+# printing parsed document works [ansi]
+
+    Code
+      print(x, n = Inf)
+    Message
+      Humans of A New Hope
+      [3m[90m{# put a comment here #}[39m[23m
+      [34m{% for person in people -%}[39m
+      [34m{% if "A New Hope" in person.films and default(person.species, "Unknown") == "Human" -%}[39m
+      * [32m{{ person.name }}[39m ([32m{{ person.homeworld }}[39m)
+      [34m{% endif -%}[39m
+      [34m{% endfor -%}[39m
+
+---
+
+    Code
+      print(x, n = 5)
+    Message
+      Humans of A New Hope
+      [3m[90m{# put a comment here #}[39m[23m
+      [34m{% for person in people -%}[39m
+      [34m{% if "A New Hope" in person.films and default(person.species, "Unknown") == "Human" -%}[39m
+      * [32m{{ person.name }}[39m ([32m{{ person.homeworld }}[39m)
+      [36mi[39m [90m... with 2 more lines[39m
+
+# printing parsed document works [unicode]
+
+    Code
+      print(x, n = Inf)
+    Message
+      Humans of A New Hope
+      {# put a comment here #}
+      {% for person in people -%}
+      {% if "A New Hope" in person.films and default(person.species, "Unknown") == "Human" -%}
+      * {{ person.name }} ({{ person.homeworld }})
+      {% endif -%}
+      {% endfor -%}
+
+---
+
+    Code
+      print(x, n = 5)
+    Message
+      Humans of A New Hope
+      {# put a comment here #}
+      {% for person in people -%}
+      {% if "A New Hope" in person.films and default(person.species, "Unknown") == "Human" -%}
+      * {{ person.name }} ({{ person.homeworld }})
+      ℹ … with 2 more lines
+
+# printing parsed document works [fancy]
+
+    Code
+      print(x, n = Inf)
+    Message
+      Humans of A New Hope
+      [3m[90m{# put a comment here #}[39m[23m
+      [34m{% for person in people -%}[39m
+      [34m{% if "A New Hope" in person.films and default(person.species, "Unknown") == "Human" -%}[39m
+      * [32m{{ person.name }}[39m ([32m{{ person.homeworld }}[39m)
+      [34m{% endif -%}[39m
+      [34m{% endfor -%}[39m
+
+---
+
+    Code
+      print(x, n = 5)
+    Message
+      Humans of A New Hope
+      [3m[90m{# put a comment here #}[39m[23m
+      [34m{% for person in people -%}[39m
+      [34m{% if "A New Hope" in person.films and default(person.species, "Unknown") == "Human" -%}[39m
+      * [32m{{ person.name }}[39m ([32m{{ person.homeworld }}[39m)
+      [36mℹ[39m [90m… with 2 more lines[39m
 
 # include tag
 

--- a/tests/testthat/test-render.R
+++ b/tests/testthat/test-render.R
@@ -12,9 +12,23 @@ test_that("templating features work", {
 test_that("storing parsed document works", {
   x <- parse_template("Hello {{ name }}!")
 
-  expect_snapshot(print(x))
   expect_equal(render(x, name = "world"), "Hello world!")
   expect_equal(render(x, name = "David"), "Hello David!")
+})
+
+cli::test_that_cli("printing parsed document works", {
+  template <- 'Humans of A New Hope
+{# put a comment here #}
+{% for person in people -%}
+{% if "A New Hope" in person.films and default(person.species, "Unknown") == "Human" -%}
+* {{ person.name }} ({{ person.homeworld }})
+{% endif -%}
+{% endfor -%}
+'
+
+  x <- parse_template(template)
+  expect_snapshot(print(x, n = Inf))
+  expect_snapshot(print(x, n = 5))
 })
 
 test_that("template files work", {

--- a/tests/testthat/test-render.R
+++ b/tests/testthat/test-render.R
@@ -29,6 +29,8 @@ cli::test_that_cli("printing parsed document works", {
   x <- parse_template(template)
   expect_snapshot(print(x, n = Inf))
   expect_snapshot(print(x, n = 5))
+
+  expect_error(print(x, n = 2.5))
 })
 
 test_that("template files work", {


### PR DESCRIPTION
Use {cli} to highlight the template blocks:
* Variables are green
* Control blocks are blue
* Comments are italic grey
* Regular text uses the default style

<img width="759" alt="image" src="https://user-images.githubusercontent.com/1804856/175853470-25be4e4a-bc6b-477e-a2cd-fb98445bf54e.png">

I needed to manually identify blocks because inja doesn't provide access to metadata like this. When color output is unsupported by the console, all this processing is skipped.


TODO:
- [x] add tests
- [x] consider how to handle long lines (text wrapping?)
  - Unnecessary since `cli::cli_verbatim()` already achieves desired behavior (wraps _and_ maintains newlines)
- [x] consider how to handle long files (argument for # lines?)
  - `print(n = 20)`