### PR TITLE
Fix error message formatting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # jinjar (development version)
 
 * `quote_sql()` now escapes single-quotes using an additional single-quote (#30).
+* Fixed edge case in how error messages are formatted (#31).
+
 
 # jinjar 0.3.0
 

--- a/R/condition.R
+++ b/R/condition.R
@@ -8,24 +8,17 @@ to_sentence_case <- function(x) {
 
 stop_inja <- function(type, message, line, column) {
   cls <- c(paste0("jinjar_", type), "jinjar_error")
+  message <- to_sentence_case(message)
+  context <- "Error occurred on {.field line {line}} and {.field column {column}}."
 
-  msg <- c(
-    to_sentence_case(message),
-    "i" = "Error occurred on {.field line {line}} and {.field column {column}}."
-  )
-
-  cli::cli_abort(msg, class = cls, call = NULL)
+  cli::cli_abort(c("{message}", "i" = context), class = cls, call = NULL)
 }
 
 stop_json <- function(message, data) {
   cls <- c("jinjar_json_error", "jinjar_error")
+  context <- "JSON object: {.val {data}}"
 
-  msg <- c(
-    message,
-    "i" = "JSON object: {.val {data}}"
-  )
-
-  cli::cli_abort(msg, class = cls, call = NULL)
+  cli::cli_abort(c("{message}", "i" = context), class = cls, call = NULL)
 }
 
 with_catch_cpp_errors <- function(expr, call = caller_env()) {


### PR DESCRIPTION
Fixes #31 

cli was attempting glue string interpolation. If the error message contains a curly brace, then this string interpolation fails.