### PR TITLE
Remove whitespace after operator""

### DIFF
--- a/src/inja/inja.hpp
+++ b/src/inja/inja.hpp
@@ -205,22 +205,22 @@ using namespace std::literals::string_view_literals;
 inline namespace literals {
 inline namespace string_view_literals {
 
-constexpr std::string_view operator"" _sv(const char *str, size_t len) noexcept // (1)
+constexpr std::string_view operator""_sv(const char *str, size_t len) noexcept // (1)
 {
   return std::string_view {str, len};
 }
 
-constexpr std::u16string_view operator"" _sv(const char16_t *str, size_t len) noexcept // (2)
+constexpr std::u16string_view operator""_sv(const char16_t *str, size_t len) noexcept // (2)
 {
   return std::u16string_view {str, len};
 }
 
-constexpr std::u32string_view operator"" _sv(const char32_t *str, size_t len) noexcept // (3)
+constexpr std::u32string_view operator""_sv(const char32_t *str, size_t len) noexcept // (3)
 {
   return std::u32string_view {str, len};
 }
 
-constexpr std::wstring_view operator"" _sv(const wchar_t *str, size_t len) noexcept // (4)
+constexpr std::wstring_view operator""_sv(const wchar_t *str, size_t len) noexcept // (4)
 {
   return std::wstring_view {str, len};
 }
@@ -1317,22 +1317,22 @@ nssv_inline_ns namespace literals {
 
 #if nssv_CONFIG_USR_SV_OPERATOR
 
-    nssv_constexpr nonstd::sv_lite::string_view operator"" _sv(const char *str, size_t len) nssv_noexcept // (1)
+    nssv_constexpr nonstd::sv_lite::string_view operator""_sv(const char *str, size_t len) nssv_noexcept // (1)
     {
       return nonstd::sv_lite::string_view {str, len};
     }
 
-    nssv_constexpr nonstd::sv_lite::u16string_view operator"" _sv(const char16_t *str, size_t len) nssv_noexcept // (2)
+    nssv_constexpr nonstd::sv_lite::u16string_view operator""_sv(const char16_t *str, size_t len) nssv_noexcept // (2)
     {
       return nonstd::sv_lite::u16string_view {str, len};
     }
 
-    nssv_constexpr nonstd::sv_lite::u32string_view operator"" _sv(const char32_t *str, size_t len) nssv_noexcept // (3)
+    nssv_constexpr nonstd::sv_lite::u32string_view operator""_sv(const char32_t *str, size_t len) nssv_noexcept // (3)
     {
       return nonstd::sv_lite::u32string_view {str, len};
     }
 
-    nssv_constexpr nonstd::sv_lite::wstring_view operator"" _sv(const wchar_t *str, size_t len) nssv_noexcept // (4)
+    nssv_constexpr nonstd::sv_lite::wstring_view operator""_sv(const wchar_t *str, size_t len) nssv_noexcept // (4)
     {
       return nonstd::sv_lite::wstring_view {str, len};
     }

--- a/src/inja/nlohmann/json.hpp
+++ b/src/inja/nlohmann/json.hpp
@@ -26387,7 +26387,7 @@ if no parse error occurred.
 @since version 1.0.0
 */
 JSON_HEDLEY_NON_NULL(1)
-inline nlohmann::json operator "" _json(const char* s, std::size_t n)
+inline nlohmann::json operator ""_json(const char* s, std::size_t n)
 {
     return nlohmann::json::parse(s, s + n);
 }
@@ -26406,7 +26406,7 @@ object if no parse error occurred.
 @since version 2.0.0
 */
 JSON_HEDLEY_NON_NULL(1)
-inline nlohmann::json::json_pointer operator "" _json_pointer(const char* s, std::size_t n)
+inline nlohmann::json::json_pointer operator ""_json_pointer(const char* s, std::size_t n)
 {
     return nlohmann::json::json_pointer(std::string(s, n));
 }


### PR DESCRIPTION
The space after `""` is deprecated since it creates ambiguity with reserved `_`-initial names per:

https://en.cppreference.com/w/cpp/language/user_literal

This might start throwing compiler warnings under `clang++-20`.